### PR TITLE
1.fixed error when reflecting an indexed property(ignore it). 2.continue...

### DIFF
--- a/fastJSON/JsonSerializer.cs
+++ b/fastJSON/JsonSerializer.cs
@@ -364,8 +364,12 @@ namespace fastJSON
             _TypesWritten = true;
             _current_depth++;
             if (_current_depth > _MAX_DEPTH)
-                throw new Exception("Serializer encountered maximum depth of " + _MAX_DEPTH);
-
+            {
+                //throw new Exception("Serializer encountered maximum depth of " + _MAX_DEPTH);
+                _output.Append('}');
+                _current_depth--;
+                return;
+            }
 
             Dictionary<string, string> map = new Dictionary<string, string>();
             Type t = obj.GetType();

--- a/fastJSON/Reflection.cs
+++ b/fastJSON/Reflection.cs
@@ -481,6 +481,10 @@ namespace fastJSON
             List<Getters> getters = new List<Getters>();
             foreach (PropertyInfo p in props)
             {
+                if (p.GetIndexParameters().Length > 0)
+                {// Property is an indexer
+                    continue;
+                }
                 if (!p.CanWrite && param.ShowReadOnlyProperties == false) continue;
                 if (param.IgnoreAttributes != null)
                 {


### PR DESCRIPTION
1.fixed error when reflecting an indexed property(ignore it). 
2.continue to reflect next object instead of throwing an exception when _current_deption > _MAX_DEPTH.