### PR TITLE
Two possible fixes ms Length varies, Timezone difference in string

### DIFF
--- a/fastJSON/JSON.cs
+++ b/fastJSON/JSON.cs
@@ -735,7 +735,7 @@ namespace fastJSON
             // - Voir "Tony" Hillaire (B9Tony) 4/12/2016
 #if net4
             return DateTime.Parse(value, null, System.Globalization.DateTimeStyles.RoundtripKind);
-#endif
+#else
             bool utc = false;
             //                   0123456789012345678 9012 9/3
             // datetime format = yyyy-MM-ddTHH:mm:ss .nnn  Z
@@ -767,6 +767,8 @@ namespace fastJSON
                 return new DateTime(year, month, day, hour, min, sec, ms);
             else
                 return new DateTime(year, month, day, hour, min, sec, ms, DateTimeKind.Utc).ToLocalTime();
+#endif
+
         }
 
         private object CreateArray(List<object> data, Type pt, Type bt, Dictionary<string, object> globalTypes)

--- a/fastJSON/JSON.cs
+++ b/fastJSON/JSON.cs
@@ -730,6 +730,12 @@ namespace fastJSON
 
         private DateTime CreateDateTime(string value)
         {
+            // This resolves the ms issue and the timezone issue brought up by bruce965 on Jan 13, 2015, 
+            // and it's faster that the previous method but it might only work on dotnet 4 and up
+            // - Voir "Tony" Hillaire (B9Tony) 4/12/2016
+#if net4
+            return DateTime.Parse(value, null, System.Globalization.DateTimeStyles.RoundtripKind);
+#endif
             bool utc = false;
             //                   0123456789012345678 9012 9/3
             // datetime format = yyyy-MM-ddTHH:mm:ss .nnn  Z
@@ -747,11 +753,15 @@ namespace fastJSON
             hour = CreateInteger(value, 11, 2);
             min = CreateInteger(value, 14, 2);
             sec = CreateInteger(value, 17, 2);
-            if (value.Length > 21 && value[19] == '.')
-                ms = CreateInteger(value, 20, 3);
-
+            // Moved so existence of 'Z' could be used in ms Length calculation - Voir "Tony" Hillaire(B9Tony) 4/12/2016
             if (value[value.Length - 1] == 'Z')
                 utc = true;
+            // changed ms Length calculation from fixed 3 to length-21 if utc Z is there or length-20 if it's not - Voir "Tony" Hillaire (B9Tony) 4/12/2016
+            // 2016-03-24T21:52:21.96Z, 2016-03-24T21:52:21.4Z, 2016-03-29T20:02:08.88, 2016-03-25T18:37:12.757Z
+            if (value.Length > 21 && value[19] == '.')
+                ms = CreateInteger(value, 20, (value.Length - (utc ? 21 : 20)));
+
+            // original location of 'Z' - utc line
 
             if (_params.UseUTCDateTime == false && utc == false)
                 return new DateTime(year, month, day, hour, min, sec, ms);


### PR DESCRIPTION
Using data obtained from a web service I found that the length of the number of milliseconds varied from 1 to 3 characters, this caused a out of bounds exception in CreateInteger() called by CreateDate which was assuming the millisecond length was 3. The fix I have in place only accounts for Z or no Z in the datetime string, it doesn't (yet) account for +-HH:MM listed in[ ISO 8601](https://www.w3.org/TR/NOTE-datetime) 

>  Year:
>       YYYY (eg 1997)
>    Year and month:
>       YYYY-MM (eg 1997-07)
>    Complete date:
>       YYYY-MM-DD (eg 1997-07-16)
>    Complete date plus hours and minutes:
>       YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
>    Complete date plus hours, minutes and seconds:
>       YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
>    Complete date plus hours, minutes, seconds and a decimal fraction of a
> second
>       YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
> where:
> 
>      YYYY = four-digit year
>      MM   = two-digit month (01=January, etc.)
>      DD   = two-digit day of month (01 through 31)
>      hh   = two digits of hour (00 through 23) (am/pm NOT allowed)
>      mm   = two digits of minute (00 through 59)
>      ss   = two digits of second (00 through 59)
>      s    = one or more digits representing a decimal fraction of a second
>      TZD  = time zone designator (Z or +hh:mm or -hh:mm)
> 

When using dotnet 4 (or greater) using: `DateTime.Parse(value, null, System.Globalization.DateTimeStyles.RoundtripKind);` performs slightly faster and handles more situations than the previous code.