### PR TITLE
fix bug when v is (object)string, e.g. "0"

### DIFF
--- a/fastJSON/JSON.cs
+++ b/fastJSON/JSON.cs
@@ -684,7 +684,7 @@ namespace fastJSON
 
                         switch (pi.Type)
                         {
-                            case myPropInfoType.Int: oset = (int)((long)v); break;
+                            case myPropInfoType.Int: oset = Convert.ToInt32(v); break;
                             case myPropInfoType.Long: oset = (long)v; break;
                             case myPropInfoType.String: oset = (string)v; break;
                             case myPropInfoType.Bool: oset = (bool)v; break;


### PR DESCRIPTION
fix bug when v is (object)string, e.g. "0"