### PR TITLE
WriteStringDictionary: use IEnumerable instead of IDictionary

### DIFF
--- a/fastJSON/JsonSerializer.cs
+++ b/fastJSON/JsonSerializer.cs
@@ -101,14 +101,17 @@ namespace fastJSON
             else if (obj is DateTimeOffset)
                 WriteDateTimeOffset((DateTimeOffset)obj);
 
+#if net4
+            else if (_params.KVStyleStringDictionary == false &&
+                obj is IEnumerable<KeyValuePair<string, object>>)
+
+                WriteStringDictionary((IEnumerable<KeyValuePair<string, object>>)obj);
+#endif
+
             else if (_params.KVStyleStringDictionary == false && obj is IDictionary &&
                 obj.GetType().IsGenericType && obj.GetType().GetGenericArguments()[0] == typeof(string))
 
                 WriteStringDictionary((IDictionary)obj);
-#if net4
-            else if (_params.KVStyleStringDictionary == false && obj is System.Dynamic.ExpandoObject)
-                WriteStringDictionary((IDictionary<string, object>)obj);
-#endif
             else if (obj is IDictionary)
                 WriteDictionary((IDictionary)obj);
 #if !SILVERLIGHT
@@ -540,7 +543,7 @@ namespace fastJSON
             _output.Append('}');
         }
 
-        private void WriteStringDictionary(IDictionary<string, object> dic)
+        private void WriteStringDictionary(IEnumerable<KeyValuePair<string, object>> dic)
         {
             _output.Append('{');
             bool pendingSeparator = false;


### PR DESCRIPTION
The current code of WriteStringDictionary doesn't use any special methods
of IDictionary. It only requires an IEnumerable<KeyValuePair<string, object>>
which eases the serialisation of custom types, because they only have to
implement the much more lightweight IEnumerable.GetEnumerator().

System.Dynamic.ExpandoObject implements IEnumerable, too, which combines
the serialisation of ExpandoObject and Dictionary<string, object>.