### PR TITLE
Support for different naming styles, and options for circular reference handling

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -1386,6 +1386,85 @@ public class tests
         Assert.AreEqual(p.o2obj, p.child.child);
     }
 
+
+    class Circular
+    {
+        public Guid Id;
+        public Circular Parent;
+        public Circular Child;
+
+        public Circular()
+        {
+            Id = Guid.NewGuid();
+        }
+
+        public static Circular Create()
+        {
+            var a = new Circular();
+            var b = new Circular() { Parent = a };
+            a.Child = b;
+            var c = new Circular() { Parent = b };
+            b.Child = c;
+            var d = new Circular() { Parent = c };
+            c.Child = d;
+            return a;
+        }
+
+    }
+
+    [Test]
+    public static void CircularReferencesThrows()
+    {
+        var obj = Circular.Create();
+
+        Assert.That(() =>
+            {
+                JSON.ToJSON(obj,
+                    new JSONParameters()
+                    {
+                        SerializerMaxDepth = 2,
+                        SerializerMaxDepthHandling = InvalidObjectActions.Throw,
+                        InlineCircularReferences = true
+                    });
+            },
+            Throws.TypeOf<Exception>());
+    }
+
+    [Test]
+    public static void CircularReferencesNull()
+    {
+        var obj = Circular.Create();
+
+        var s = JSON.ToJSON(obj,
+            new JSONParameters()
+            {
+                SerializeNullValues = false,
+                SerializerMaxDepth = 3,
+                SerializerMaxDepthHandling = InvalidObjectActions.InsertNull,
+                InlineCircularReferences = true
+            });
+        Console.WriteLine(JSON.Beautify(s));
+        StringAssert.Contains("null", s);
+    }
+
+    [Test]
+    public static void CircularReferencesEmpty()
+    {
+        var obj = Circular.Create();
+
+        var s = JSON.ToJSON(obj,
+            new JSONParameters()
+            {
+                SerializeNullValues = false,
+                SerializerMaxDepth = 4,
+                SerializerMaxDepthHandling = InvalidObjectActions.InsertEmpty,
+                InlineCircularReferences = true
+            });
+        Console.WriteLine(s);
+        Console.WriteLine(JSON.Beautify(s));
+        StringAssert.Contains("{}", s);
+    }
+
     public class lol
     {
         public List<List<object>> r;
@@ -1625,7 +1704,7 @@ public class tests
         r.Field1 = "dsasdF";
         r.Field2 = 2312;
         r.date = DateTime.Now;
-        var s = JSON.ToNiceJSON(r, new JSONParameters { SerializeToLowerCaseNames = true });
+        var s = JSON.ToNiceJSON(r, new JSONParameters { NamingStyle = NamingStyles.LowerCase });
         Console.WriteLine(s);
         var o = JSON.ToObject(s);
         Assert.IsNotNull(o);
@@ -1633,6 +1712,32 @@ public class tests
         Assert.AreEqual(2312, (o as Retclass).Field2);
     }
 
+    [Test]
+    public static void PropertyName_Normal()
+    {
+        var obj = new { NameProperty = "Test" };
+        var s = JSON.ToJSON(obj, new JSONParameters { NamingStyle = NamingStyles.Normal, EnableAnonymousTypes = true });
+        Console.WriteLine(s);
+        Assert.AreEqual("{\"NameProperty\":\"Test\"}", s);
+    }
+
+    [Test]
+    public static void PropertyName_LowerCase()
+    {
+        var obj = new { NameProperty = "Test" };
+        var s = JSON.ToJSON(obj, new JSONParameters { NamingStyle = NamingStyles.LowerCase, EnableAnonymousTypes = true });
+        Console.WriteLine(s);
+        Assert.AreEqual("{\"nameproperty\":\"Test\"}", s);
+    }
+
+    [Test]
+    public static void PropertyName_CamelCase()
+    {
+        var obj = new { NameProperty = "Test" };
+        var s = JSON.ToJSON(obj, new JSONParameters { NamingStyle = NamingStyles.CamelCase, EnableAnonymousTypes = true });
+        Console.WriteLine(s);
+        Assert.AreEqual("{\"nameProperty\":\"Test\"}",s);
+    }
 
     public class nulltest
     {

--- a/fastJSON/JSON.cs
+++ b/fastJSON/JSON.cs
@@ -12,6 +12,40 @@ namespace fastJSON
 {
     public delegate string Serialize(object data);
     public delegate object Deserialize(string data);
+    public delegate string TextHandler(string name);
+    public delegate void InvalidObjectHandler(object obj);
+
+    public enum NamingStyles
+    {
+        /// <summary>
+        /// Leave name as is
+        /// </summary>
+        Normal = 0,
+        /// <summary>
+        /// Transform to lower case
+        /// </summary>
+        LowerCase = 1,
+        /// <summary>
+        /// Transform to camel case (Lowers the first char)
+        /// </summary>
+        CamelCase = 2
+    }
+
+    public enum InvalidObjectActions
+    {
+        /// <summary>
+        /// Throws an exception
+        /// </summary>
+        Throw = 0,
+        /// <summary>
+        /// Inserts a "null"
+        /// </summary>
+        InsertNull = 1,
+        /// <summary>
+        /// Inserts an empty object "{}"
+        /// </summary>
+        InsertEmpty = 2
+    }
 
     public sealed class JSONParameters
     {
@@ -83,13 +117,22 @@ namespace fastJSON
         /// </summary>
         public byte SerializerMaxDepth = 20;
         /// <summary>
+        /// Default action for when the <see cref="SerializerMaxDepth"/> limit is hit.
+        /// </summary>
+        public InvalidObjectActions SerializerMaxDepthHandling = InvalidObjectActions.Throw;
+        /// <summary>
         /// Inline circular or already seen objects instead of replacement with $i (default = False) 
         /// </summary>
         public bool InlineCircularReferences = false;
         /// <summary>
         /// Save property/field names as lowercase (default = false)
         /// </summary>
+        [Obsolete("Use the NamingStyle property instead")]
         public bool SerializeToLowerCaseNames = false;
+        /// <summary>
+        /// Naming style for property/field name (default = normal, leave as is)
+        /// </summary>
+        public NamingStyles NamingStyle = NamingStyles.Normal;
         /// <summary>
         /// Formatter indent spaces (default = 3)
         /// </summary>
@@ -1206,6 +1249,39 @@ namespace fastJSON
         }
 #endif
         #endregion
+    }
+
+    internal class nameHandler
+    {
+        private readonly TextHandler _handle;
+
+        internal nameHandler(NamingStyles style)
+        {
+            switch (style)
+            {
+                case NamingStyles.LowerCase:
+                    _handle = (s) => s.ToLower();
+                    break;
+                case NamingStyles.CamelCase:
+                    _handle = (s) =>
+                    {
+                        var chars = s.ToCharArray();
+                        chars[0] = Char.ToLowerInvariant(chars[0]);
+                        return new string(chars);
+                    };
+                    break;
+                case NamingStyles.Normal:
+                default:
+                    _handle = (s) => s;
+                    break;
+            }
+        }
+
+        internal string Handle(string name)
+        {
+            return _handle(name);
+        }
+
     }
 
 }

--- a/fastJSON/Reflection.cs
+++ b/fastJSON/Reflection.cs
@@ -16,6 +16,7 @@ namespace fastJSON
     {
         public string Name;
         public string lcName;
+        public string ccName;
         public string memberName;
         public Reflection.GenericGetter Getter;
     }
@@ -92,6 +93,7 @@ namespace fastJSON
         private SafeDictionary<string, Dictionary<string, myPropInfo>> _propertycache = new SafeDictionary<string, Dictionary<string, myPropInfo>>();
         private SafeDictionary<Type, Type[]> _genericTypes = new SafeDictionary<Type, Type[]>();
         private SafeDictionary<Type, Type> _genericTypeDef = new SafeDictionary<Type, Type>();
+        private readonly nameHandler _ccNameHandler = new nameHandler(NamingStyles.CamelCase);
 
         #region bjson custom types
         internal UnicodeEncoding unicode = new UnicodeEncoding();
@@ -592,7 +594,7 @@ namespace fastJSON
                 #endif
                 GenericGetter g = CreateGetMethod(type, p);
                 if (g != null)
-                    getters.Add(new Getters { Getter = g, Name = p.Name, lcName = p.Name.ToLower(), memberName = mName });
+                    getters.Add(new Getters { Getter = g, Name = p.Name, lcName = p.Name.ToLower(), ccName = _ccNameHandler.Handle(p.Name), memberName = mName });
             }
 
             FieldInfo[] fi = type.GetFields(bf);
@@ -631,7 +633,7 @@ namespace fastJSON
                 {
                     GenericGetter g = CreateGetField(type, f);
                     if (g != null)
-                        getters.Add(new Getters { Getter = g, Name = f.Name, lcName = f.Name.ToLower(), memberName = mName });
+                        getters.Add(new Getters { Getter = g, Name = f.Name, lcName = f.Name.ToLower(), ccName = _ccNameHandler.Handle(f.Name), memberName = mName });
                 }
             }
             val = getters.ToArray();


### PR DESCRIPTION
Added support for different object naming styles: (Enum)
- Normal (Default)
- LowerCase
- CamelCase

Added support for handling when the SerializerMaxDepth limit is hit: (Enum)
- Throw (Defaults to the current behavior)
- InsertNull ("obj":"null")
- InsertEmpty ("obj":"{}")

(I was replacing Json.Net with fastJSON in a MVC5 project, and needed the same behavior.)