### PR TITLE
More flexible RegisterCustomType

### DIFF
--- a/fastJSON/JsonSerializer.cs
+++ b/fastJSON/JsonSerializer.cs
@@ -236,9 +236,11 @@ namespace fastJSON
 
         private void WriteCustom(object obj)
         {
-            Serialize s;
-            Reflection.Instance._customSerializer.TryGetValue(obj.GetType(), out s);
-            WriteStringFast(s(obj));
+            CustomConverter s;
+            Reflection.Instance.customTypes.TryGetValue(obj.GetType(), out s);
+            WriteValue(s.serialize(obj));
+            //_output.Append(s(obj));
+            //WriteStringFast(s(obj));
         }
 
         private void WriteEnum(Enum e)


### PR DESCRIPTION
Instead of converting string to object, now it can convert any known type to object

here is an example with result {"$types":{"ConsoleApp8.Test":"1"},"$type":"1","custom":3}

```csharp
using System;
using System.Diagnostics;
using System.IO;
using fastJSON;

namespace ConsoleApp8
{
    class Program
    {
        static void Main(string[] args)
        {
            JSON.RegisterCustomType<CustomType, int>(a => a.value, a => new CustomType() { value = a });

            var json = Serializer.Serialize(new Test() { custom = new CustomType() { value = 3 } });
            Console.WriteLine(json);
            var t = Serializer.Deserialize<Test>(json);
            Debug.Assert(t.custom.value == 3);

            Console.ReadLine();
        }
    }
    public struct CustomType
    {
        public int value;
    }
    public class Test
    {
        public CustomType custom = new CustomType();
    }
}
